### PR TITLE
TFS Mapping Paths.

### DIFF
--- a/src/GitTfs/Globals.cs
+++ b/src/GitTfs/Globals.cs
@@ -27,10 +27,12 @@ namespace GitTfs
                         v => UserSpecifiedRemoteId = v },
                     { "A|authors=", "Path to an Authors file to map TFS users to Git users (will be kept in cache and used for all the following commands)",
                         v => AuthorsFilePath = v },
+                    { "M|mapping=", "Path to a mapping file; a txt file in each line 2 paths separated by semicolon (;). The first path is the relative path in the TFS trunk and the second path the intended path in the target git repository",
+                        v => MappingFilePath = v },
                 };
             }
         }
-
+        public string MappingFilePath { get; set; }
         public string AuthorsFilePath { get; set; }
         public bool ShowHelp { get; set; }
         public bool ShowVersion { get; set; }

--- a/src/GitTfs/Util/MappingsFile.cs
+++ b/src/GitTfs/Util/MappingsFile.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+using GitTfs.Core;
+using System.Diagnostics;
+using System.Linq;
+
+namespace GitTfs.Util
+{
+    public class Mapping
+    {
+        public Mapping(string tfsPath, string localPath)
+        {
+            TfsPath = tfsPath;
+            LocalPath = (localPath ?? string.Empty).TrimStart('/');
+        }
+
+        public string TfsPath { get; set; }
+        public string LocalPath { get; set; }
+
+
+        public string LocalPathWithRoot(string root)
+        {
+            return Path.Combine(root, LocalPath);
+        }
+
+        public string TfsPathWithRoot(string root)
+        {
+            return string.IsNullOrWhiteSpace(TfsPath) ? root.TrimEnd('/') : $"{root.TrimEnd('/')}/{TfsPath.TrimStart('/')}";
+        }
+    }
+
+    [StructureMapSingleton]
+    public class MappingsFile
+    {
+        private readonly List<Mapping> _mappings = new List<Mapping>();
+        
+        public MappingsFile()
+        { }
+
+        public bool IsParseSuccessfull { get; set; }
+
+        public static string GitTfsCachedMappingFileName = "git-tfs_mappings";
+
+        public List<Mapping> Mappings => _mappings;
+
+
+        public bool Parse(string filePath)
+        {
+            try
+            {
+                _mappings.Clear();
+
+                var mappings = File.ReadAllLines(filePath).Where(line => !string.IsNullOrWhiteSpace(line)).Select(line =>
+                {
+                    var paths = line.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries).Select(t => t.Trim()).ToList();
+                    return new Mapping(paths[0],  paths.Count >= 2 ? paths[1] : string.Empty);
+                });
+
+                _mappings.AddRange(mappings);
+            }
+            catch (Exception e)
+            {
+                throw new GitTfsException($"Unable to parse mapping file {filePath}",e);
+            }
+            
+            IsParseSuccessfull = true;
+            return true;
+        }
+
+        public bool Parse(string filePath, string gitDir, bool couldSaveAuthorFile)
+        {
+            if (string.IsNullOrWhiteSpace(filePath))
+            {
+                return LoadMappingsFromSavedFile(gitDir);
+            }
+
+            if (!File.Exists(filePath))
+            {
+                throw new GitTfsException("Mappings file cannot be found: '" + filePath + "'");
+            }
+
+            if (couldSaveAuthorFile)
+            {
+                SaveMappingFileInRepository(filePath, gitDir);
+            }
+
+            Trace.WriteLine("Reading authors file : " + filePath);
+            return Parse(filePath);
+
+        }
+
+        private string GetSavedMappingFilePath(string gitDir)
+        {
+            return Path.Combine(gitDir, GitTfsCachedMappingFileName);
+        }
+        
+        public void SaveMappingFileInRepository(string filePath, string gitDir)
+        {
+            if(string.IsNullOrWhiteSpace(filePath))
+                return;
+
+            var savedMappingFilePath = GetSavedMappingFilePath(gitDir);
+            try
+            {
+                File.Copy(filePath, savedMappingFilePath, true);
+            }
+            catch (Exception)
+            {
+                Trace.TraceWarning("Failed to copy authors file from \"" + filePath + "\" to \"" +
+                                   savedMappingFilePath + "\".");
+            }
+        }
+
+        public bool LoadMappingsFromSavedFile(string gitDir)
+        {
+            var savedMappingFilePath = GetSavedMappingFilePath(gitDir);
+            if (!File.Exists(savedMappingFilePath))
+            {
+                Trace.WriteLine("No mappings file used.");
+                return false;
+            }
+
+            if (Mappings.Count != 0)
+                return true;
+            Trace.WriteLine("Reading cached mappings file (" + savedMappingFilePath + ")...");
+            return Parse(savedMappingFilePath);
+        }
+
+       
+
+    }
+}

--- a/src/GitTfs/Util/PathResolver.cs
+++ b/src/GitTfs/Util/PathResolver.cs
@@ -10,7 +10,7 @@ namespace GitTfs.Util
         private readonly IGitTfsRemote _remote;
         private readonly string _relativePath;
         private readonly IDictionary<string, GitObject> _initialTree;
-
+        
         public PathResolver(IGitTfsRemote remote, string relativePath, IDictionary<string, GitObject> initialTree)
         {
             _remote = remote;
@@ -63,7 +63,7 @@ namespace GitTfs.Util
             {
                 var dirName = splitResult.Groups["dir"].Value;
                 var fileName = splitResult.Groups["file"].Value;
-                fullPath = Lookup(dirName).Path + "/" + fileName;
+                fullPath = (Lookup(dirName).Path + "/" + fileName).TrimStart('/');
             }
             result = new GitObject { Path = fullPath };
             _initialTree[fullPath] = result;


### PR DESCRIPTION
These changes are intended for large TFS structures where there are many
solutions within the same trunk. Instead of using the subtree command
which changes the history by renaming the files, the new mapping feature
will map only specific TFS folders to a git repository. The mapping will
also allow the restructure of the folder tree.

---Please read and delete this text before creating this pull request---
Thanks a lot for the pull request you are going to do!
Please verify that you validate these points:

- [ ] indentation is made with 4 spaces
- [ ] your pull request contains only changes intended (no refactoring, line return added, ... that could make code review harder. Make another one if you think it is needed...)
- [ ] run and verify that existing tests pass. Add some new units tests, if needed.
- [ ] update the documentation, if needed.
- [ ] update the [release notes file](../tree/master/doc/release-notes/NEXT.md)

------------------------------------------------------------------------