### PR TITLE
Mappings - do not include history log entries in git if all changes are fully filtered out.

### DIFF
--- a/src/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/src/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -186,6 +186,8 @@ namespace GitTfs.VsCommon
                 changesets = Retry.Do(() => VersionControl.QueryHistory(path, lastChangeset, 0, RecursionType.Full,
                     null, startChangeset, lastChangeset, BatchCount, true, true, true, true)
                     .Cast<Changeset>().ToArray());
+
+                Trace.WriteLine($"changeSets length {changesets.Length} {startChangeset} {lastChangeset} ");
                 if (changesets.Length > 0)
                     start = changesets[changesets.Length - 1].ChangesetId + 1;
 
@@ -944,7 +946,7 @@ namespace GitTfs.VsCommon
                 _bridge.Wrap<WrapperForVersionControlServer, VersionControlServer>(VersionControl);
             // TODO - containerify this (no `new`)!
             var fakeChangeset = new Unshelveable(shelveset, change, wrapperForVersionControlServer, _bridge);
-            var tfsChangeset = new TfsChangeset(remote.Tfs, fakeChangeset, null, null) { Summary = new TfsChangesetInfo { Remote = remote } };
+            var tfsChangeset = new TfsChangeset(remote.Tfs, fakeChangeset, null, null, null) { Summary = new TfsChangesetInfo { Remote = remote } };
             return tfsChangeset;
         }
 

--- a/src/GitTfs.VsCommon/TfsHelper.Common.cs
+++ b/src/GitTfs.VsCommon/TfsHelper.Common.cs
@@ -716,7 +716,7 @@ namespace GitTfs.VsCommon
                 while (Directory.Exists(localDirectory))
                     localDirectory = baseFolder + $"-{i++}";
 
-                Trace.WriteLine($"Setting up a TFS workspace {remote.TfsRepositoryPath} => {localDirectory}");
+                Trace.TraceInformation($"Setting up a TFS workspace {remote.TfsRepositoryPath} => {localDirectory}");
                 
                 //add mappings to workplace
                 List<WorkingFolder> folders = null;

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -385,6 +385,7 @@ namespace GitTfs.Core
                     {
                         MaxChangesetId = changeset.Summary.ChangesetId;
                         fetchResult.LastFetchedChangesetId = changeset.Summary.ChangesetId;
+                        Trace.TraceWarning($"!changeset{changeset.BaseChangesetId}.HasChanges");
                         continue;
                     }
 
@@ -392,6 +393,7 @@ namespace GitTfs.Core
                     {
                         fetchResult.NewChangesetCount--; // Merge wasn't successful - so don't count the changeset we found
                         fetchResult.IsSuccess = false;
+                        Trace.TraceWarning($"changeset{changeset.BaseChangesetId}.IsMergeChangeset");
                         return fetchResult;
                     }
                     var parentSha = (renameResult != null && renameResult.IsProcessingRenameChangeset) ? renameResult.LastParentCommitBeforeRename : MaxCommitHash;
@@ -407,6 +409,7 @@ namespace GitTfs.Core
                         {
                             fetchResult.IsProcessingRenameChangeset = true;
                             fetchResult.LastParentCommitBeforeRename = MaxCommitHash;
+                            Trace.TraceWarning($"changeset{changeset.BaseChangesetId}.IsRenameChangeset");
                             return fetchResult;
                         }
                         renameResult.IsProcessingRenameChangeset = false;

--- a/src/GitTfs/Core/GitTfsRemote.cs
+++ b/src/GitTfs/Core/GitTfsRemote.cs
@@ -397,6 +397,10 @@ namespace GitTfs.Core
                     var parentSha = (renameResult != null && renameResult.IsProcessingRenameChangeset) ? renameResult.LastParentCommitBeforeRename : MaxCommitHash;
                     var isFirstCommitInRepository = (parentSha == null);
                     var log = Apply(parentSha, changeset, objects);
+
+
+                    //if more than one mappings, then we might have multiple first commits
+                    //add the first commit:  && changeset.BaseChangesetId != 10793)
                     if (changeset.IsRenameChangeset && !isFirstCommitInRepository)
                     {
                         if (renameResult == null || !renameResult.IsProcessingRenameChangeset)
@@ -775,15 +779,15 @@ namespace GitTfs.Core
 
             // (performance) If mappings then fetch only the changeSets from the specific paths and not from the whole trunk
             // The following comment does not work since there is a common lowerBoundChangesetId (paging) for multiple mapping folders.
-            //if (_mappingsFile.Mappings.Count > 0 && !string.IsNullOrWhiteSpace(TfsRepositoryPath))
-            //{
-            //    var m1 = _mappingsFile
-            //        .Mappings
-            //        .SelectMany(m => Tfs.GetChangesets(m.TfsPathWithRoot(TfsRepositoryPath), lowerBoundChangesetId, this, lastVersion, byLots))
-            //        .OrderBy(x => x.Summary.ChangesetId).ToList();
-            //    return m1;
-            //}
-            
+            if (_mappingsFile.Mappings.Count > 0 && !string.IsNullOrWhiteSpace(TfsRepositoryPath))
+            {
+                var m1 = _mappingsFile
+                    .Mappings
+                    .SelectMany(m => Tfs.GetChangesets(m.TfsPathWithRoot(TfsRepositoryPath), lowerBoundChangesetId, this, lastVersion, byLots))
+                    .OrderBy(x => x.Summary.ChangesetId).ToList();
+                return m1;
+            }
+
             if (!IsSubtreeOwner)
                 return Tfs.GetChangesets(TfsRepositoryPath, lowerBoundChangesetId, this, lastVersion, byLots);
 

--- a/src/GitTfs/Core/ITfsChangeset.cs
+++ b/src/GitTfs/Core/ITfsChangeset.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using GitTfs.Util;
 
 namespace GitTfs.Core
 {
@@ -9,6 +10,8 @@ namespace GitTfs.Core
         int BaseChangesetId { get; }
         LogEntry Apply(string lastCommit, IGitTreeModifier treeBuilder, ITfsWorkspace workspace, IDictionary<string, GitObject> initialTree, Action<Exception> ignorableErrorHandler, Util.FileFilter filters);
         LogEntry CopyTree(IGitTreeModifier treeBuilder, ITfsWorkspace workspace);
+
+        bool HasChanges(FileFilter filter);
 
         /// <summary>
         /// Get all items (files and folders) in the source TFS repository.

--- a/src/GitTfs/Core/TfsChangeset.cs
+++ b/src/GitTfs/Core/TfsChangeset.cs
@@ -105,6 +105,12 @@ namespace GitTfs.Core
             }
         }
 
+        public bool HasChanges(FileFilter filters)
+        {
+            var filteredChanges = _changeset.Changes.Where(cs => filters == null || filters.IncludeItem(cs));
+            return filteredChanges.Any();
+        }
+
         public IEnumerable<TfsTreeEntry> GetFullTree()
         {
             var treeInfo = Summary.Remote.Repository.CreateObjectsDictionary();

--- a/src/GitTfs/Core/TfsChangeset.cs
+++ b/src/GitTfs/Core/TfsChangeset.cs
@@ -14,15 +14,17 @@ namespace GitTfs.Core
         private readonly IChangeset _changeset;
         private readonly AuthorsFile _authors;
         private readonly MappingsFile _mappingsFile;
+        private readonly ExcludedRenamesFile _excludedRenamesFile;
         public TfsChangesetInfo Summary { get; set; }
         public int BaseChangesetId { get; set; }
 
-        public TfsChangeset(ITfsHelper tfs, IChangeset changeset, AuthorsFile authors, MappingsFile mappingsFile)
+        public TfsChangeset(ITfsHelper tfs, IChangeset changeset, AuthorsFile authors, MappingsFile mappingsFile, ExcludedRenamesFile excludedRenamesFile)
         {
             _tfs = tfs;
             _changeset = changeset;
             _authors = authors;
             _mappingsFile = mappingsFile;
+            _excludedRenamesFile = excludedRenamesFile;
             BaseChangesetId = _changeset.Changes.Max(c => c.Item.ChangesetId) - 1;
         }
 
@@ -42,7 +44,7 @@ namespace GitTfs.Core
             
             var remoteRelativeLocalPath = GetPathRelativeToWorkspaceLocalPath(workspace);
             var resolver = new PathResolver(Summary.Remote, remoteRelativeLocalPath, initialTree);
-            var sieve = new ChangeSieve(_changeset, resolver, filters);
+            var sieve = new ChangeSieve(_changeset, resolver, filters, _excludedRenamesFile);
             if (sieve.RenameBranchCommmit)
             {
                 IsRenameChangeset = true;

--- a/src/GitTfs/Globals.cs
+++ b/src/GitTfs/Globals.cs
@@ -29,10 +29,13 @@ namespace GitTfs
                         v => AuthorsFilePath = v },
                     { "M|mapping=", "Path to a mapping file; a txt file in each line 2 paths separated by semicolon (;). The first path is the relative path in the TFS trunk and the second path the intended path in the target git repository",
                         v => MappingFilePath = v },
+                    { "excludedrenames=", "Path to a excluded renames file; a txt file in each line 1 changeset id that should not be marked as rename only commit",
+                        v => ExcludedRenamesFilePath = v },
                 };
             }
         }
         public string MappingFilePath { get; set; }
+        public string ExcludedRenamesFilePath { get; set; }
         public string AuthorsFilePath { get; set; }
         public bool ShowHelp { get; set; }
         public bool ShowVersion { get; set; }

--- a/src/GitTfs/Util/FileFilter.cs
+++ b/src/GitTfs/Util/FileFilter.cs
@@ -53,9 +53,9 @@ namespace GitTfs.Util
         {
             if (ExtensionsToFilter.Any (e => change.Item.ServerItem.EndsWith (e, StringComparison.InvariantCultureIgnoreCase)))
                 return false;
-            if (WhiteListPaths != null && ! WhiteListPaths.Any (p => change.Item.ServerItem.StartsWith (p, StringComparison.InvariantCultureIgnoreCase)))
+            if (WhiteListPaths != null && WhiteListPaths.Count != 0 && !WhiteListPaths.Any(p => change.Item.ServerItem.StartsWith (p, StringComparison.InvariantCultureIgnoreCase)))
                 return false;
-            if (BlackListPaths != null && BlackListPaths.Any (p => change.Item.ServerItem.StartsWith (p, StringComparison.InvariantCultureIgnoreCase)))
+            if (BlackListPaths != null && BlackListPaths.Count != 0 && BlackListPaths.Any(p => change.Item.ServerItem.StartsWith (p, StringComparison.InvariantCultureIgnoreCase)))
                 return false;
 
             if (change.Item.ContentLength > MaxFileSize)

--- a/src/GitTfs/Util/MappingsFile.cs
+++ b/src/GitTfs/Util/MappingsFile.cs
@@ -86,7 +86,7 @@ namespace GitTfs.Util
                 SaveMappingFileInRepository(filePath, gitDir);
             }
 
-            Trace.WriteLine("Reading authors file : " + filePath);
+            Trace.WriteLine("Reading mappings file : " + filePath);
             return Parse(filePath);
 
         }


### PR DESCRIPTION
Mappings - do not include history log entries in git if all changes are fully filtered out.

Adding comment on the performance issue for getting only the combining changesets of the mapping folders. Due to the way the paging for fetching the changesets works, this is not supported for now.
